### PR TITLE
Change FillRadarHoles tests to pytest fixtures

### DIFF
--- a/improver_tests/nowcasting/utilities/test_FillRadarHoles.py
+++ b/improver_tests/nowcasting/utilities/test_FillRadarHoles.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
 # (C) British Crown Copyright 2017-2019 Met Office.
@@ -41,8 +40,9 @@ from improver.nowcasting.utilities import FillRadarHoles
 from ...set_up_test_cubes import set_up_variable_cube
 
 
-def create_masked_rainrate_data():
-    """Create a masked data array of rain rates in mm/h"""
+@pytest.fixture(name="rainrate")
+def rainrate_fixture() -> Cube:
+    """Masked rain rates in mm/h"""
     nonzero_data = np.array(
         [
             [0.03, 0.1, 0.1, 0.1, 0.03],
@@ -56,73 +56,65 @@ def create_masked_rainrate_data():
     data[5:12, 5:12] = np.full((7, 7), 0.03, dtype=np.float32)
     data[6:11, 6:11] = nonzero_data.astype(np.float32)
     mask = np.where(np.isfinite(data), False, True)
-    return MaskedArray(data, mask=mask)
+    m_data = MaskedArray(data, mask=mask)
+    cube = set_up_variable_cube(
+        m_data, name="lwe_precipitation_rate", units="mm h-1", spatial_grid="equalarea"
+    )
+    return cube
 
 
-RAIN_DATA = create_masked_rainrate_data()
-
-# first case: speckle, rates in mm/h
-RAIN_CUBE = set_up_variable_cube(
-    RAIN_DATA, name="lwe_precipitation_rate", units="mm h-1", spatial_grid="equalarea"
-)
-
-INTERPOLATED_RAIN = RAIN_DATA.copy()
-INTERPOLATED_RAIN.data[7:10, 8:10] = [
-    [0.2, 0.07138586],
-    [0.11366593, 0.09165306],
-    [0.09488520, 0.07650946],
-]
-INTERPOLATED_RAIN.mask = np.full(INTERPOLATED_RAIN.shape, False)
-
-# second case: speckle, rates in m/s
-MS_RAIN_CUBE = RAIN_CUBE.copy()
-MS_RAIN_CUBE.convert_units("m s-1")
-
-MS_INTERPOLATED_RAIN = INTERPOLATED_RAIN / (3600.0 * 1000.0)
-
-# third case: widespread mask
-MASKED_RAIN_CUBE = RAIN_CUBE.copy()
-MASKED_RAIN_CUBE.data[:11, :11] = np.nan
-MASKED_RAIN_CUBE.data.mask = np.where(
-    np.isfinite(MASKED_RAIN_CUBE.data.data), False, True
-)
-
-# set up alternate test cases for which interpolation should ("speckle_*")
-# and should not ("masked") be triggered
-CASES = ["speckle_mmh", "speckle_ms", "masked"]
-INPUT_CUBES = {
-    "speckle_mmh": RAIN_CUBE,
-    "speckle_ms": MS_RAIN_CUBE,
-    "masked": MASKED_RAIN_CUBE,
-}
-OUTPUT_DATA = {
-    "speckle_mmh": INTERPOLATED_RAIN,
-    "speckle_ms": MS_INTERPOLATED_RAIN,
-    "masked": MASKED_RAIN_CUBE.data.copy(),
-}
-
-PLUGIN = FillRadarHoles()
+@pytest.fixture(name="interp_rainrate")
+def interp_rainrate_fixture(rainrate) -> MaskedArray:
+    """Interpolated rain rates, expected output from applying FillRadarHoles"""
+    data = rainrate.data
+    data[7:10, 8:10] = [
+        [0.2, 0.07138586],
+        [0.11366593, 0.09165306],
+        [0.09488520, 0.07650946],
+    ]
+    data.mask = np.full_like(data, False)
+    return data
 
 
-def test_basic():
-    """Test that the plugin returns a masked cube"""
-    result = PLUGIN(RAIN_CUBE)
+def check_fillradarholes(result, expected):
+    """Results comparison for test functions"""
     assert isinstance(result, Cube)
     assert isinstance(result.data, MaskedArray)
+    np.testing.assert_allclose(result.data, expected.data, rtol=1e-5, atol=1e-8)
+    np.testing.assert_array_equal(result.data.mask, expected.mask)
 
 
-@pytest.mark.parametrize("case", CASES)
-def test_values(case):
-    """Test that the data and mask contain the expected values"""
-    result = PLUGIN(INPUT_CUBES[case])
-    assert np.allclose(result.data, OUTPUT_DATA[case])
-    assert np.array_equal(result.data.mask, OUTPUT_DATA[case].mask)
+def test_mm_hour(rainrate, interp_rainrate):
+    """Test filling radar holes in units of mm/h"""
+    plugin = FillRadarHoles()
+    result = plugin(rainrate)
+    check_fillradarholes(result, interp_rainrate)
 
 
-def test_log_transform_reversability():
+def test_metres_sec(rainrate, interp_rainrate):
+    """Test filling radar holes in units of m/s"""
+    plugin = FillRadarHoles()
+    rainrate.convert_units("m s-1")
+    result = plugin(rainrate)
+    expected = interp_rainrate / (3600.0 * 1000.0)
+    check_fillradarholes(result, expected)
+
+
+def test_wide_mask(rainrate):
+    """Test filling radar holes with a widespread mask,
+    interpolation should not be triggered in this case"""
+    plugin = FillRadarHoles()
+    rainrate.data[:11, :11] = np.nan
+    rainrate.data.mask = np.where(np.isfinite(rainrate.data.data), False, True)
+    result = plugin(rainrate)
+    check_fillradarholes(result, rainrate.data.copy())
+
+
+def test_log_transform_reversability(rainrate):
     """Test that data in mm h-1 are reproduced when transforming to
     and from log rainrates"""
-    log_rr = PLUGIN._rr_to_log_rr(RAIN_CUBE.data)
-    assert all(np.isnan(log_rr[np.where(RAIN_CUBE.data == 0)]))
-    rr = PLUGIN._log_rr_to_rr(log_rr)
-    assert np.allclose(rr, RAIN_CUBE.data)
+    plugin = FillRadarHoles()
+    log_rr = plugin._rr_to_log_rr(rainrate.data)
+    np.testing.assert_array_equal(log_rr[np.where(rainrate.data == 0)], np.nan)
+    rr = plugin._log_rr_to_rr(log_rr)
+    np.testing.assert_allclose(rr, rainrate.data)


### PR DESCRIPTION
PR-to-PR on metoppv/improver#1233

Modify the unit tests for FillRadarHoles to use pytest fixtures. This avoids use of many module level constants.

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)
