### PR TITLE
Improves grammar in metadata interpreter for realization data

### DIFF
--- a/improver/developer_tools/metadata_interpreter.py
+++ b/improver/developer_tools/metadata_interpreter.py
@@ -570,7 +570,11 @@ def display_interpretation(interpreter, verbose=False):
 
     field_type = interpreter.field_type.replace("_", " ")
     output = []
-    output.append(f"This is a {interpreter.prod_type} {field_type} file")
+    if field_type == "realizations":
+        field_type_clause = f"file containing one or more {field_type}"
+    else:
+        field_type_clause = f"{field_type} file"
+    output.append(f"This is a {interpreter.prod_type} {field_type_clause}")
     if verbose:
         output.append(vstring("name, coordinates"))
 

--- a/improver_tests/developer_tools/test_MOMetadataInterpreter.py
+++ b/improver_tests/developer_tools/test_MOMetadataInterpreter.py
@@ -218,7 +218,9 @@ def test_error_wrong_percentile_name_units(wind_gust_percentile_cube, interprete
     with pytest.raises(ValueError, match=msg):
         interpreter.run(wind_gust_percentile_cube)
 
+
 # Test attribute errors
+
 
 def test_error_forbidden_attributes(wind_gust_percentile_cube, interpreter):
     """Test error raised when a forbidden attribute is present"""
@@ -253,6 +255,8 @@ def test_warning_wind_gust_attribute_wrong_diagnostic(
         "'wind_gust_diagnostic']) include unexpected attributes ['wind_gust_diagnostic']. "
         "Please check the standard to ensure this is valid."
     ]
+
+
 # Test cell method errors
 
 
@@ -283,7 +287,9 @@ def test_error_wrong_accum_cell_method(precip_accum_cube, interpreter):
     with pytest.raises(ValueError, match="Expected sum over time"):
         interpreter.run(precip_accum_cube)
 
+
 # Test probabilistic metadata errors
+
 
 def test_error_invalid_probability_name(probability_above_cube, interpreter):
     """Test error raised if probability cube name is invalid"""
@@ -363,6 +369,8 @@ def test_error_inconsistent_relative_to_threshold(probability_above_cube, interp
         ValueError, match="name.*above.*is not consistent with.*less_than"
     ):
         interpreter.run(probability_above_cube)
+
+
 # Test errors related to time coordinates
 
 
@@ -380,7 +388,9 @@ def test_error_time_coord_units(probability_above_cube, interpreter):
     with pytest.raises(ValueError, match="does not have required units"):
         interpreter.run(probability_above_cube)
 
+
 # Test the interpreter can return multiple errors.
+
 
 def test_multiple_error_concatenation(probability_above_cube, interpreter):
     """Test multiple errors are concatenated and returned correctly in a readable
@@ -398,7 +408,9 @@ def test_multiple_error_concatenation(probability_above_cube, interpreter):
     with pytest.raises(ValueError, match=msg):
         interpreter.run(probability_above_cube)
 
+
 # Test errors for cell methods that aren't compliant with the standard.
+
 
 def test_error_forbidden_cell_method(blended_probability_below_cube, interpreter):
     """Test error raised when a forbidden cell method is present"""
@@ -421,7 +433,9 @@ def test_error_probability_cell_method_no_comment(
     ):
         interpreter.run(blended_probability_below_cube)
 
-# Test errors caused by time coordinate bounds 
+
+# Test errors caused by time coordinate bounds
+
 
 def test_error_missing_time_bounds(blended_probability_below_cube, interpreter):
     """Test error raised if a minimum in time cube has no time bounds"""
@@ -438,7 +452,9 @@ def test_error_incorrect_time_bounds(blended_probability_below_cube, interpreter
     with pytest.raises(ValueError, match="points should be equal to upper bounds"):
         interpreter.run(blended_probability_below_cube)
 
+
 # Tests for metadata related to blending
+
 
 def test_error_missing_blended_coords(blended_probability_below_cube, interpreter):
     """Test error raised if a blended cube doesn't have the expected time
@@ -473,7 +489,9 @@ def test_error_blend_missing_from_title(blended_probability_below_cube, interpre
     with pytest.raises(ValueError, match="is not a valid single model"):
         interpreter.run(blended_probability_below_cube)
 
+
 # Test errors due to incorrect spot metadata
+
 
 def test_error_missing_spot_coords(blended_spot_median_cube, interpreter):
     """Test error raised if a spot cube doesn't have all the expected metadata"""
@@ -490,7 +508,9 @@ def test_error_inconsistent_spot_title(blended_spot_median_cube, interpreter):
     with pytest.raises(ValueError, match="not consistent with spot data"):
         interpreter.run(blended_spot_median_cube)
 
+
 # Test errors related to special cases
+
 
 def test_error_forbidden_wind_direction_cell_method(wind_direction_cube, interpreter):
     """Test error if special case cubes have a cell method that would usually be

--- a/improver_tests/developer_tools/test_display_interpretation.py
+++ b/improver_tests/developer_tools/test_display_interpretation.py
@@ -45,7 +45,7 @@ def test_unhandled(emos_coefficient_cube, interpreter):
 def test_realizations(ensemble_cube, interpreter):
     """Test interpretation of temperature realizations from MOGREPS-UK"""
     expected_result = (
-        "This is a gridded realizations file\n"
+        "This is a gridded file containing one or more realizations\n"
         "It contains realizations of air temperature\n"
         "It has undergone no significant post-processing\n"
         "It contains data from MOGREPS-UK\n"
@@ -166,7 +166,7 @@ def test_verbose_snow_level(snow_level_cube, interpreter):
     """Test interpretation of a diagnostic cube with "probability" in the name,
     which is not designed for blending with other models"""
     expected_result = (
-        "This is a gridded realizations file\n"
+        "This is a gridded file containing one or more realizations\n"
         "    Source: name, coordinates\n"
         "It contains realizations of probability of snow falling level below ground level\n"
         "    Source: name, threshold coordinate (probabilities only)\n"


### PR DESCRIPTION
Updates display_interpretation function to say "one or more realizations" for data in diagnostic-space.

Addresses comments in #1433 and fixed Black issue.

Testing:
 - [x] Ran tests and they passed OK
